### PR TITLE
Fix deprecation warning by explicitly selecting a mock backend

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,1 +1,5 @@
+RSpec.configure do |config|
+  config.mock_with :rspec
+end
+
 require 'puppetlabs_spec_helper/module_spec_helper'


### PR DESCRIPTION
```
puppetlabs_spec_helper: defaults `mock_with` to `:mocha`. See https://github.com/puppetlabs/puppetlabs_spec_helper#mock_with to choose a sensible value for you

If you need more of the backtrace for any of these deprecations to
identify where to make the necessary changes, you can configure
`config.raise_errors_for_deprecations!`, and it will turn the
deprecation warnings into errors, giving you the full backtrace.

1 deprecation warning total
```

Select rspec as the backend as this seems to be the future path.